### PR TITLE
2주차 과제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,25 @@
 plugins {
     id 'java'
+    id 'org.springframework.boot' version '3.2.4'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'org.sopt'
 version = '1.0-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 03 21:57:33 KST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -1,89 +1,13 @@
 package org.sopt;
-import org.sopt.controller.PostController;
-import org.sopt.dto.request.CreatePostRequest;
-import org.sopt.dto.response.CreatePostResponse;
-import org.sopt.dto.response.PostResponse;
 
-import java.util.List;
-import java.util.Scanner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+// @SpringBootApplication 안에 @ComponentScan이 포함됨
+// 이 어노테이션이 붙은 클래스(Main)의 하위 패키지를 모두 스캔해서 Bean으로 등록
+@SpringBootApplication
 public class Main {
     public static void main(String[] args) {
-        // 클라이언트는 Controller만 알면 돼요. Service도 Repository도 몰라도 돼요.
-        // PostController가 클라에서 응답을 받아오고, 서버에는 그냥 전달해주는 역할 수행
-        PostController postController = new PostController();
-        Scanner scanner = new Scanner(System.in);
-        boolean running = true;
-
-        while (running) {
-            System.out.println("\n=== 에브리타임 게시판 ===");
-            System.out.println("1. 게시글 작성");
-            System.out.println("2. 전체 조회");
-            System.out.println("3. 단건 조회");
-            System.out.println("4. 게시글 수정");
-            System.out.println("5. 게시글 삭제");
-            System.out.println("0. 종료");
-            System.out.print("메뉴 선택: ");
-
-            int choice = scanner.nextInt();
-            scanner.nextLine();
-
-            switch (choice) {
-                case 1:
-                    System.out.print("제목: ");
-                    String title = scanner.nextLine();
-                    System.out.print("내용: ");
-                    String content = scanner.nextLine();
-                    System.out.print("작성자: ");
-                    String author = scanner.nextLine();
-                    // 클라이언트가 요청 객체를 만들어서 Controller에 전달
-                    CreatePostResponse response = postController.createPost(
-                            new CreatePostRequest(title, content, author)
-                    );
-                    System.out.println(response.message);
-                    break;
-
-                case 2:
-                    List<PostResponse> posts = postController.getAllPosts();
-                    if (posts.isEmpty()) {
-                        System.out.println("등록된 게시글이 없습니다.");
-                    } else {
-                        posts.forEach(p -> System.out.println(p + "\n---"));
-                    }
-                    break;
-
-                case 3:
-                    System.out.print("조회할 게시글 ID: ");
-                    PostResponse post = postController.getPost(scanner.nextLong());
-                    scanner.nextLine();
-                    if (post != null) System.out.println(post);
-                    break;
-
-                case 4:
-                    System.out.print("수정할 게시글 ID: ");
-                    Long updateId = scanner.nextLong();
-                    scanner.nextLine();
-                    System.out.print("새 제목: ");
-                    String newTitle = scanner.nextLine();
-                    System.out.print("새 내용: ");
-                    String newContent = scanner.nextLine();
-                    postController.updatePost(updateId, newTitle, newContent);
-                    break;
-
-                case 5:
-                    System.out.print("삭제할 게시글 ID: ");
-                    postController.deletePost(scanner.nextLong());
-                    scanner.nextLine();
-                    break;
-
-                case 0:
-                    running = false;
-                    System.out.println("👋 프로그램 종료");
-                    break;
-                default:
-                    System.out.println("❗ 잘못된 입력입니다.");
-            }
-        }
-        scanner.close();
+        SpringApplication.run(Main.class, args);
     }
 }

--- a/src/main/java/org/sopt/common/ErrorCode.java
+++ b/src/main/java/org/sopt/common/ErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 /**
  * 에러 응답에 사용될 상태 코드 + 커스텀 코드 + 메시지 모음
  * 예외를 던지거나 GlobalExceptionHandler에서 응답 조립할 때 사용.
- *
+ * <p>
  * getCode()는 enum 자체의 name()을 반환하므로 커스텀 코드 문자열을 따로 넣어줄 필요 없음.
  * 즉 TITLE_REQUIRED.getCode() == "TITLE_REQUIRED"
  */
@@ -16,7 +16,10 @@ public enum ErrorCode {
     TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "제목은 50자 이하여야 합니다."),
     CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "내용은 2000자 이하여야 합니다."),
     TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "이미지는 최대 10개까지 첨부 가능합니다."),
-    INVALID_PAGINATION_PARAMETER(HttpStatus.BAD_REQUEST, "페이지 파라미터가 유효하지 않습니다. (page: 0 이상, size: 1~50)"),
+    INVALID_PAGINATION_PARAMETER(
+            HttpStatus.BAD_REQUEST,
+            "페이지 파라미터가 유효하지 않습니다. (page: 0 이상, size: 1~50)"
+    ),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 파라미터를 확인해주세요."),
 
     // 401 Unauthorized — 인증 실패
@@ -30,7 +33,10 @@ public enum ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않거나 삭제되었습니다."),
 
     // 500 Internal Server Error — 서버 오류
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 이용이 일시적으로 원활하지 않습니다. 잠시 후 다시 시도해주세요.");
+    INTERNAL_SERVER_ERROR(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "서버 이용이 일시적으로 원활하지 않습니다. 잠시 후 다시 시도해주세요."
+    );
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt/common/ErrorCode.java
+++ b/src/main/java/org/sopt/common/ErrorCode.java
@@ -1,0 +1,55 @@
+package org.sopt.common;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 에러 응답에 사용될 상태 코드 + 커스텀 코드 + 메시지 모음
+ * 예외를 던지거나 GlobalExceptionHandler에서 응답 조립할 때 사용.
+ */
+public enum ErrorCode {
+
+    // 400 Bad Request — 입력 검증 실패
+    TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "TITLE_REQUIRED", "제목을 입력해주세요."),
+    TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "TITLE_TOO_LONG", "제목은 50자 이하여야 합니다."),
+    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "CONTENT_TOO_LONG", "내용은 2000자 이하여야 합니다."),
+    TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "TOO_MANY_IMAGES", "이미지는 최대 10개까지 첨부 가능합니다."),
+    INVALID_PAGINATION_PARAMETER(HttpStatus.BAD_REQUEST, "INVALID_PAGINATION_PARAMETER",
+            "페이지 파라미터가 유효하지 않습니다. (page: 0 이상, size: 1~50)"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "요청 파라미터를 확인해주세요."),
+
+    // 401 Unauthorized — 인증 실패
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "LOGIN_REQUIRED", "로그인이 필요한 서비스입니다."),
+
+    // 403 Forbidden — 권한 없음
+    FORBIDDEN_DELETE(HttpStatus.FORBIDDEN, "FORBIDDEN_DELETE", "본인이 작성한 글만 삭제할 수 있습니다."),
+    FORBIDDEN_UPDATE(HttpStatus.FORBIDDEN, "FORBIDDEN_UPDATE", "본인이 작성한 글만 수정할 수 있습니다."),
+
+    // 404 Not Found — 리소스 없음
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글이 존재하지 않거나 삭제되었습니다."),
+
+    // 500 Internal Server Error — 서버 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR",
+            "서버 이용이 일시적으로 원활하지 않습니다. 잠시 후 다시 시도해주세요.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/common/ErrorCode.java
+++ b/src/main/java/org/sopt/common/ErrorCode.java
@@ -5,39 +5,38 @@ import org.springframework.http.HttpStatus;
 /**
  * 에러 응답에 사용될 상태 코드 + 커스텀 코드 + 메시지 모음
  * 예외를 던지거나 GlobalExceptionHandler에서 응답 조립할 때 사용.
+ *
+ * getCode()는 enum 자체의 name()을 반환하므로 커스텀 코드 문자열을 따로 넣어줄 필요 없음.
+ * 즉 TITLE_REQUIRED.getCode() == "TITLE_REQUIRED"
  */
 public enum ErrorCode {
 
     // 400 Bad Request — 입력 검증 실패
-    TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "TITLE_REQUIRED", "제목을 입력해주세요."),
-    TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "TITLE_TOO_LONG", "제목은 50자 이하여야 합니다."),
-    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "CONTENT_TOO_LONG", "내용은 2000자 이하여야 합니다."),
-    TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "TOO_MANY_IMAGES", "이미지는 최대 10개까지 첨부 가능합니다."),
-    INVALID_PAGINATION_PARAMETER(HttpStatus.BAD_REQUEST, "INVALID_PAGINATION_PARAMETER",
-            "페이지 파라미터가 유효하지 않습니다. (page: 0 이상, size: 1~50)"),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "요청 파라미터를 확인해주세요."),
+    TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "제목을 입력해주세요."),
+    TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "제목은 50자 이하여야 합니다."),
+    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "내용은 2000자 이하여야 합니다."),
+    TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "이미지는 최대 10개까지 첨부 가능합니다."),
+    INVALID_PAGINATION_PARAMETER(HttpStatus.BAD_REQUEST, "페이지 파라미터가 유효하지 않습니다. (page: 0 이상, size: 1~50)"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 파라미터를 확인해주세요."),
 
     // 401 Unauthorized — 인증 실패
-    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "LOGIN_REQUIRED", "로그인이 필요한 서비스입니다."),
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
 
     // 403 Forbidden — 권한 없음
-    FORBIDDEN_DELETE(HttpStatus.FORBIDDEN, "FORBIDDEN_DELETE", "본인이 작성한 글만 삭제할 수 있습니다."),
-    FORBIDDEN_UPDATE(HttpStatus.FORBIDDEN, "FORBIDDEN_UPDATE", "본인이 작성한 글만 수정할 수 있습니다."),
+    FORBIDDEN_DELETE(HttpStatus.FORBIDDEN, "본인이 작성한 글만 삭제할 수 있습니다."),
+    FORBIDDEN_UPDATE(HttpStatus.FORBIDDEN, "본인이 작성한 글만 수정할 수 있습니다."),
 
     // 404 Not Found — 리소스 없음
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND", "해당 게시글이 존재하지 않거나 삭제되었습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않거나 삭제되었습니다."),
 
     // 500 Internal Server Error — 서버 오류
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR",
-            "서버 이용이 일시적으로 원활하지 않습니다. 잠시 후 다시 시도해주세요.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 이용이 일시적으로 원활하지 않습니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
-    private final String code;
     private final String message;
 
-    ErrorCode(HttpStatus status, String code, String message) {
+    ErrorCode(HttpStatus status, String message) {
         this.status = status;
-        this.code = code;
         this.message = message;
     }
 
@@ -45,8 +44,9 @@ public enum ErrorCode {
         return status;
     }
 
+    // enum이 자동으로 제공하는 name() 사용 — 상수명을 그대로 String으로 반환
     public String getCode() {
-        return code;
+        return name();
     }
 
     public String getMessage() {

--- a/src/main/java/org/sopt/common/SuccessCode.java
+++ b/src/main/java/org/sopt/common/SuccessCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 /**
  * 성공 응답에 사용될 상태코드 + 커스텀코드 + 메시지
  * ApiResponse.success(...) 호출 시 SuccessCode enum 넘겨주기
- *
+ * <p>
  * getCode()는 enum 자체의 name()을 반환하므로 커스텀 코드 문자열을 따로 넣어줄 필요 없음.
  * 즉 POST_CREATE_SUCCESS.getCode() == "POST_CREATE_SUCCESS"
  */

--- a/src/main/java/org/sopt/common/SuccessCode.java
+++ b/src/main/java/org/sopt/common/SuccessCode.java
@@ -5,28 +5,26 @@ import org.springframework.http.HttpStatus;
 /**
  * 성공 응답에 사용될 상태코드 + 커스텀코드 + 메시지
  * ApiResponse.success(...) 호출 시 SuccessCode enum 넘겨주기
+ *
+ * getCode()는 enum 자체의 name()을 반환하므로 커스텀 코드 문자열을 따로 넣어줄 필요 없음.
+ * 즉 POST_CREATE_SUCCESS.getCode() == "POST_CREATE_SUCCESS"
  */
 public enum SuccessCode {
 
     // enum 상수에 괄호로 인자 넘기면 -> 그 enum의 생성자 호출
     // -> 컴파일러가 static final 인스턴스 생성으로 번역해주는 문법!
     // 외부에서 접근 시 SuccessCode.POST_LIST_FETCH_SUCCESS와 같이 접근하면 됨
-    POST_LIST_FETCH_SUCCESS(HttpStatus.OK, "POST_LIST_FETCH_SUCCESS",
-            "게시글 목록 조회에 성공했습니다."), POST_DETAIL_FETCH_SUCCESS(HttpStatus.OK,
-            "POST_DETAIL_FETCH_SUCCESS",
-            "게시글 조회에 성공했습니다."), POST_CREATE_SUCCESS(HttpStatus.CREATED,
-            "POST_CREATE_SUCCESS", "게시글이 성공적으로 등록되었습니다."), POST_UPDATE_SUCCESS(
-            HttpStatus.OK, "POST_UPDATE_SUCCESS",
-            "게시글이 성공적으로 수정되었습니다."), POST_DELETE_SUCCESS(HttpStatus.OK,
-            "POST_DELETE_SUCCESS", "게시글이 삭제되었습니다.");
+    POST_LIST_FETCH_SUCCESS(HttpStatus.OK, "게시글 목록 조회에 성공했습니다."),
+    POST_DETAIL_FETCH_SUCCESS(HttpStatus.OK, "게시글 조회에 성공했습니다."),
+    POST_CREATE_SUCCESS(HttpStatus.CREATED, "게시글이 성공적으로 등록되었습니다."),
+    POST_UPDATE_SUCCESS(HttpStatus.OK, "게시글이 성공적으로 수정되었습니다."),
+    POST_DELETE_SUCCESS(HttpStatus.OK, "게시글이 삭제되었습니다.");
 
-    private final HttpStatus status; // HTTP 상태 코드
-    private final String code; // 서버 커스텀 코드 문자열
-    private final String message; // 사용자에게 보여줄 메시지
+    private final HttpStatus status;
+    private final String message;
 
-    SuccessCode(HttpStatus status, String code, String message) {
+    SuccessCode(HttpStatus status, String message) {
         this.status = status;
-        this.code = code;
         this.message = message;
     }
 
@@ -34,13 +32,12 @@ public enum SuccessCode {
         return status;
     }
 
+    // enum이 자동으로 제공하는 name() 사용 — 상수명을 그대로 String으로 반환
     public String getCode() {
-        return code;
+        return name();
     }
 
     public String getMessage() {
         return message;
     }
-
-    ;
 }

--- a/src/main/java/org/sopt/common/SuccessCode.java
+++ b/src/main/java/org/sopt/common/SuccessCode.java
@@ -1,0 +1,46 @@
+package org.sopt.common;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 성공 응답에 사용될 상태코드 + 커스텀코드 + 메시지
+ * ApiResponse.success(...) 호출 시 SuccessCode enum 넘겨주기
+ */
+public enum SuccessCode {
+
+    // enum 상수에 괄호로 인자 넘기면 -> 그 enum의 생성자 호출
+    // -> 컴파일러가 static final 인스턴스 생성으로 번역해주는 문법!
+    // 외부에서 접근 시 SuccessCode.POST_LIST_FETCH_SUCCESS와 같이 접근하면 됨
+    POST_LIST_FETCH_SUCCESS(HttpStatus.OK, "POST_LIST_FETCH_SUCCESS",
+            "게시글 목록 조회에 성공했습니다."), POST_DETAIL_FETCH_SUCCESS(HttpStatus.OK,
+            "POST_DETAIL_FETCH_SUCCESS",
+            "게시글 조회에 성공했습니다."), POST_CREATE_SUCCESS(HttpStatus.CREATED,
+            "POST_CREATE_SUCCESS", "게시글이 성공적으로 등록되었습니다."), POST_UPDATE_SUCCESS(
+            HttpStatus.OK, "POST_UPDATE_SUCCESS",
+            "게시글이 성공적으로 수정되었습니다."), POST_DELETE_SUCCESS(HttpStatus.OK,
+            "POST_DELETE_SUCCESS", "게시글이 삭제되었습니다.");
+
+    private final HttpStatus status; // HTTP 상태 코드
+    private final String code; // 서버 커스텀 코드 문자열
+    private final String message; // 사용자에게 보여줄 메시지
+
+    SuccessCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    ;
+}

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -5,7 +5,6 @@ import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.ApiResponse;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
-import org.sopt.exception.PostNotFoundException;
 import org.sopt.service.PostService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +12,13 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-// RestController = Controller + ResponseBody 합본
+// @RestController = @Controller + @ResponseBody
 // 반환 객체를 자동으로 JSON으로 변환해서 HTTP 응답 Body에 실어준다
 @RestController // 이 클래스는 REST API 진입점
-@RequestMapping("/posts") // 모든 메서드는 URL 앞에 /posts 자동으로 붙임
+// 클라가 'HTTP 메서드 + URL'같은 RESTful한 요청(ex: GET /posts)을 보내면
+// Spring의 HandlerMapping이 앱 시작 시 @RequestMapping으로 만들어둔 라우팅 테이블('HTTP메서드+URL'에 일치하는 메서드가 key-value로 저장) 조회
+// -> 그 조합에 매칭되는 Controller 메서드(ex: getAllPosts)를 호출
+@RequestMapping("/posts")
 public class PostController {
     private final PostService postService;
 
@@ -30,6 +32,7 @@ public class PostController {
     @PostMapping // POST /posts 매핑
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(@RequestBody CreatePostRequest request) {
         CreatePostResponse response = postService.createPost(request);
+        // ResponseEntity.status(): 원하는 상태 코드 지정 가능
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(201, "게시글 등록 완료!", response));
     }
 
@@ -38,6 +41,7 @@ public class PostController {
     @GetMapping // /posts
     public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
         List<PostResponse> responses = postService.getAllPosts();
+        // ResponseEntity.ok(): .status(HTTPStatus.OK)의 단축형, 200 전용
         return ResponseEntity.ok(ApiResponse.success(responses));
     }
 

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,12 +1,12 @@
 package org.sopt.controller;
 
+import org.sopt.common.SuccessCode;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.ApiResponse;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.service.PostService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,22 +28,22 @@ public class PostController {
 
     // POST /posts
     // @RequestBody: 클라로부터 온 HTTP Body의 JSON을 CreatePostRequest 객체로 자동 변환
-    // ResponseEntity<T>: 상태 코드(201 Created)와 Body를 함께 반환
+    // SuccessCode 안에 status + code + message 다 들어있어서 그걸 그대로 꺼내 응답에 세팅
     @PostMapping // POST /posts 매핑
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(@RequestBody CreatePostRequest request) {
         CreatePostResponse response = postService.createPost(request);
-        // ResponseEntity.status(): 원하는 상태 코드 지정 가능
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(201, "게시글 등록 완료!", response));
+        return ResponseEntity
+                .status(SuccessCode.POST_CREATE_SUCCESS.getStatus())
+                .body(ApiResponse.success(SuccessCode.POST_CREATE_SUCCESS, response));
     }
 
     // GET /posts
-    // 성공 시 200 OK + 게시글 리스트를 ApiResponse로 감싸서 반환
-    @GetMapping // /posts
+    @GetMapping
     public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
         List<PostResponse> responses = postService.getAllPosts();
-        // ResponseEntity.ok(): .status(HTTPStatus.OK)의 단축형, 200 전용
-        return ResponseEntity.ok(ApiResponse.success(responses));
+        return ResponseEntity
+                .status(SuccessCode.POST_LIST_FETCH_SUCCESS.getStatus())
+                .body(ApiResponse.success(SuccessCode.POST_LIST_FETCH_SUCCESS, responses));
     }
 
     // GET /posts/{id}
@@ -52,22 +52,28 @@ public class PostController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<PostResponse>> getPost(@PathVariable Long id) {
         PostResponse response = postService.getPost(id);
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity
+                .status(SuccessCode.POST_DETAIL_FETCH_SUCCESS.getStatus())
+                .body(ApiResponse.success(SuccessCode.POST_DETAIL_FETCH_SUCCESS, response));
     }
 
     // PUT /posts/{id}
-    // 반환할 페이로드가 없으므로 data는 null, 타입은 Void.
+    // 반환할 페이로드가 없으므로 data=null 오버로드 사용
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> updatePost(@PathVariable Long id, @RequestBody UpdatePostRequest request) {
         postService.updatePost(id, request);
-        return ResponseEntity.ok(ApiResponse.success(200, "게시글 수정 완료", null));
+        return ResponseEntity
+                .status(SuccessCode.POST_UPDATE_SUCCESS.getStatus())
+                .body(ApiResponse.success(SuccessCode.POST_UPDATE_SUCCESS));
     }
 
     // DELETE /posts/{id}
-    // 위와 같은 이유로 200 OK + data=null.
+    // 위와 같은 이유로 data=null
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
         postService.deletePost(id);
-        return ResponseEntity.ok(ApiResponse.success(200, "게시글 삭제 완료", null));
+        return ResponseEntity
+                .status(SuccessCode.POST_DELETE_SUCCESS.getStatus())
+                .body(ApiResponse.success(SuccessCode.POST_DELETE_SUCCESS));
     }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -2,6 +2,7 @@ package org.sopt.controller;
 
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
+import org.sopt.dto.response.ApiResponse;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.exception.PostNotFoundException;
@@ -27,41 +28,41 @@ public class PostController {
     // @RequestBody: 클라로부터 온 HTTP Body의 JSON을 CreatePostRequest 객체로 자동 변환
     // ResponseEntity<T>: 상태 코드(201 Created)와 Body를 함께 반환
     @PostMapping // POST /posts 매핑
-    public ResponseEntity<CreatePostResponse> createPost(@RequestBody CreatePostRequest request) {
+    public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(@RequestBody CreatePostRequest request) {
         CreatePostResponse response = postService.createPost(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(201, "게시글 등록 완료!", response));
     }
 
     // GET /posts
-    // 성공 시 200 OK + 게시글 리스트 반환
+    // 성공 시 200 OK + 게시글 리스트를 ApiResponse로 감싸서 반환
     @GetMapping // /posts
-    public ResponseEntity<List<PostResponse>> getAllPosts() {
+    public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
         List<PostResponse> responses = postService.getAllPosts();
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(ApiResponse.success(responses));
     }
 
     // GET /posts/{id}
     // @PathVariable: URL 경로의 {id} 값을 Long id 파라미터로 주입
     // 없는 아이디면 Service에서 PostNotFoundException 발생 -> GlobalExceptionHandler에서 처리
     @GetMapping("/{id}")
-    public ResponseEntity<PostResponse> getPost(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<PostResponse>> getPost(@PathVariable Long id) {
         PostResponse response = postService.getPost(id);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // PUT /posts/{id}
-    // 성공 시 204 No Content (응답 Body 없음이 관례)
+    // 반환할 페이로드가 없으므로 data는 null, 타입은 Void.
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updatePost(@PathVariable Long id, @RequestBody UpdatePostRequest request) {
+    public ResponseEntity<ApiResponse<Void>> updatePost(@PathVariable Long id, @RequestBody UpdatePostRequest request) {
         postService.updatePost(id, request);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.success(200, "게시글 수정 완료", null));
     }
 
     // DELETE /posts/{id}
-    // 성공 시 204 No Content
+    // 위와 같은 이유로 200 OK + data=null.
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
         postService.deletePost(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.success(200, "게시글 삭제 완료", null));
     }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -33,7 +33,8 @@ public class PostController {
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(@RequestBody CreatePostRequest request) {
         CreatePostResponse response = postService.createPost(request);
         // ResponseEntity.status(): 원하는 상태 코드 지정 가능
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(201, "게시글 등록 완료!", response));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(201, "게시글 등록 완료!", response));
     }
 
     // GET /posts

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,57 +1,67 @@
 package org.sopt.controller;
 
 import org.sopt.dto.request.CreatePostRequest;
+import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.exception.PostNotFoundException;
 import org.sopt.service.PostService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+// RestController = Controller + ResponseBody 합본
+// 반환 객체를 자동으로 JSON으로 변환해서 HTTP 응답 Body에 실어준다
+@RestController // 이 클래스는 REST API 진입점
+@RequestMapping("/posts") // 모든 메서드는 URL 앞에 /posts 자동으로 붙임
 public class PostController {
-    private final PostService postService = new PostService();
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
 
     // POST /posts
-    public CreatePostResponse createPost(CreatePostRequest request) {
-        try {
-            return postService.createPost(request);
-        } catch (IllegalArgumentException e) {
-            return new CreatePostResponse(null, "🚫 " + e.getMessage());
-        }
+    // @RequestBody: 클라로부터 온 HTTP Body의 JSON을 CreatePostRequest 객체로 자동 변환
+    // ResponseEntity<T>: 상태 코드(201 Created)와 Body를 함께 반환
+    @PostMapping // POST /posts 매핑
+    public ResponseEntity<CreatePostResponse> createPost(@RequestBody CreatePostRequest request) {
+        CreatePostResponse response = postService.createPost(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    // GET /posts 📝 과제
-    public List<PostResponse> getAllPosts() {
-        return postService.getAllPosts();
+    // GET /posts
+    // 성공 시 200 OK + 게시글 리스트 반환
+    @GetMapping // /posts
+    public ResponseEntity<List<PostResponse>> getAllPosts() {
+        List<PostResponse> responses = postService.getAllPosts();
+        return ResponseEntity.ok(responses);
     }
 
-    // GET /posts/{id} 📝 과제
-    public PostResponse getPost(Long id) {
-        try {
-            return postService.getPost(id);
-        } catch (PostNotFoundException e) {
-            System.out.println("🚫 " + e.getMessage());
-            return null;
-        }
+    // GET /posts/{id}
+    // @PathVariable: URL 경로의 {id} 값을 Long id 파라미터로 주입
+    // 없는 아이디면 Service에서 PostNotFoundException 발생 -> GlobalExceptionHandler에서 처리
+    @GetMapping("/{id}")
+    public ResponseEntity<PostResponse> getPost(@PathVariable Long id) {
+        PostResponse response = postService.getPost(id);
+        return ResponseEntity.ok(response);
     }
 
-    // PUT /posts/{id} 📝 과제
-    public void updatePost(Long id, String newTitle, String newContent) {
-        try {
-            postService.updatePost(id, newTitle, newContent);
-        } catch (PostNotFoundException e) {
-            System.out.println("🚫 " + e.getMessage());
-        } catch (IllegalArgumentException e) {
-            System.out.println("🚫 " + e.getMessage());
-        }
+    // PUT /posts/{id}
+    // 성공 시 204 No Content (응답 Body 없음이 관례)
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updatePost(@PathVariable Long id, @RequestBody UpdatePostRequest request) {
+        postService.updatePost(id, request);
+        return ResponseEntity.noContent().build();
     }
 
-    // DELETE /posts/{id} 📝 과제
-    public void deletePost(Long id) {
-        try {
-            postService.deletePost(id);
-        } catch (PostNotFoundException e) {
-            System.out.println("🚫 " + e.getMessage());
-        }
+    // DELETE /posts/{id}
+    // 성공 시 204 No Content
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long id) {
+        postService.deletePost(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,16 +1,16 @@
 package org.sopt.controller;
 
 import org.sopt.common.SuccessCode;
+import org.sopt.domain.BoardType;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.ApiResponse;
 import org.sopt.dto.response.CreatePostResponse;
+import org.sopt.dto.response.PageResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.service.PostService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 // @RestController = @Controller + @ResponseBody
 // 반환 객체를 자동으로 JSON으로 변환해서 HTTP 응답 Body에 실어준다
@@ -32,18 +32,23 @@ public class PostController {
     @PostMapping // POST /posts 매핑
     public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(@RequestBody CreatePostRequest request) {
         CreatePostResponse response = postService.createPost(request);
-        return ResponseEntity
-                .status(SuccessCode.POST_CREATE_SUCCESS.getStatus())
+        return ResponseEntity.status(SuccessCode.POST_CREATE_SUCCESS.getStatus())
                 .body(ApiResponse.success(SuccessCode.POST_CREATE_SUCCESS, response));
     }
 
     // GET /posts
     @GetMapping
-    public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
-        List<PostResponse> responses = postService.getAllPosts();
-        return ResponseEntity
-                .status(SuccessCode.POST_LIST_FETCH_SUCCESS.getStatus())
-                .body(ApiResponse.success(SuccessCode.POST_LIST_FETCH_SUCCESS, responses));
+    public ResponseEntity<ApiResponse<PageResponse<PostResponse>>> getAllPosts(
+            // defaultValue: 클라에서 값 안보내면 이 기본값이 들어가 있는 상태로 진행, null 절대 불가
+            // required = false: 클라에서 값 안보내면 null이 들어감
+            // 게시판 전체조회 / 특정 게시판 조회를 구분해야하므로 null 가능한게 자연스러움
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) BoardType boardType
+    ) {
+        PageResponse<PostResponse> pageData = postService.getAllPosts(page, size, boardType);
+        return ResponseEntity.status(SuccessCode.POST_LIST_FETCH_SUCCESS.getStatus())
+                .body(ApiResponse.success(SuccessCode.POST_LIST_FETCH_SUCCESS, pageData));
     }
 
     // GET /posts/{id}
@@ -52,18 +57,19 @@ public class PostController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<PostResponse>> getPost(@PathVariable Long id) {
         PostResponse response = postService.getPost(id);
-        return ResponseEntity
-                .status(SuccessCode.POST_DETAIL_FETCH_SUCCESS.getStatus())
+        return ResponseEntity.status(SuccessCode.POST_DETAIL_FETCH_SUCCESS.getStatus())
                 .body(ApiResponse.success(SuccessCode.POST_DETAIL_FETCH_SUCCESS, response));
     }
 
     // PUT /posts/{id}
     // 반환할 페이로드가 없으므로 data=null 오버로드 사용
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> updatePost(@PathVariable Long id, @RequestBody UpdatePostRequest request) {
+    public ResponseEntity<ApiResponse<Void>> updatePost(
+            @PathVariable Long id,
+            @RequestBody UpdatePostRequest request
+    ) {
         postService.updatePost(id, request);
-        return ResponseEntity
-                .status(SuccessCode.POST_UPDATE_SUCCESS.getStatus())
+        return ResponseEntity.status(SuccessCode.POST_UPDATE_SUCCESS.getStatus())
                 .body(ApiResponse.success(SuccessCode.POST_UPDATE_SUCCESS));
     }
 
@@ -72,8 +78,7 @@ public class PostController {
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
         postService.deletePost(id);
-        return ResponseEntity
-                .status(SuccessCode.POST_DELETE_SUCCESS.getStatus())
+        return ResponseEntity.status(SuccessCode.POST_DELETE_SUCCESS.getStatus())
                 .body(ApiResponse.success(SuccessCode.POST_DELETE_SUCCESS));
     }
 }

--- a/src/main/java/org/sopt/domain/BoardType.java
+++ b/src/main/java/org/sopt/domain/BoardType.java
@@ -1,0 +1,19 @@
+package org.sopt.domain;
+
+/**
+ * 게시판 종류 enum.
+ * - FREE: 자유게시판
+ * - HOT: HOT 게시판
+ * - SECRET: 비밀 게시판
+ * <p>
+ * 클라이언트는 JSON으로 "FREE" / "HOT" / "SECRET" 문자열을 보내고,
+ * Jackson이 자동으로 enum 상수로 변환해준다
+ * (잘못된 값이면 Spring이 400 응답 -- GlobalExceptionHandler에서 처리)
+ * <p>
+ * Post(비즈니스 개념)의 속성이므로 domain에 선언
+ */
+public enum BoardType {
+    FREE,
+    HOT,
+    SECRET
+}

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -8,7 +8,14 @@ public class Post {
     private String createdAt;   // 목록, 상세 화면 — 작성 시각
     private BoardType boardType; // 게시판 종류 (FREE / HOT / SECRET)
 
-    public Post(Long id, String title, String content, String author, String createdAt, BoardType boardType) {
+    public Post(
+            Long id,
+            String title,
+            String content,
+            String author,
+            String createdAt,
+            BoardType boardType
+    ) {
         this.id = id;
         this.title = title;
         this.content = content;

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -15,11 +15,25 @@ public class Post {
         this.createdAt = createdAt;
     }
 
-    public Long getId() { return id; }
-    public String getTitle() { return title; }
-    public String getContent() { return content; }
-    public String getAuthor() { return author; }
-    public String getCreatedAt() { return createdAt; }
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
 
     public void update(String title, String content) {
         this.title = title;

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -1,18 +1,20 @@
 package org.sopt.domain;
 
 public class Post {
-    private Long id;          // 게시글 상세 화면 — 특정 게시글 식별용
-    private String title;     // 목록, 상세, 글쓰기 화면 — 제목
-    private String content;   // 목록(미리보기), 상세(전체) 화면 — 내용
-    private String author;    // 목록, 상세 화면 — 글쓴이
-    private String createdAt; // 목록, 상세 화면 — 작성 시각
+    private Long id;            // 게시글 상세 화면 — 특정 게시글 식별용
+    private String title;       // 목록, 상세, 글쓰기 화면 — 제목
+    private String content;     // 목록(미리보기), 상세(전체) 화면 — 내용
+    private String author;      // 목록, 상세 화면 — 글쓴이
+    private String createdAt;   // 목록, 상세 화면 — 작성 시각
+    private BoardType boardType; // 게시판 종류 (FREE / HOT / SECRET)
 
-    public Post(Long id, String title, String content, String author, String createdAt) {
+    public Post(Long id, String title, String content, String author, String createdAt, BoardType boardType) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.author = author;
         this.createdAt = createdAt;
+        this.boardType = boardType;
     }
 
     public Long getId() {
@@ -33,6 +35,10 @@ public class Post {
 
     public String getCreatedAt() {
         return createdAt;
+    }
+
+    public BoardType getBoardType() {
+        return boardType;
     }
 
     public void update(String title, String content) {

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -8,9 +8,6 @@ import org.sopt.domain.BoardType;
 // 네 값을 받는 생성자 자동 생성
 // 각 필드에 대응하는 접근자 메서드 title(), content(), author(), boardType() 자동 생성
 public record CreatePostRequest(
-        String title,
-        String content,
-        String author,
-        BoardType boardType
+        String title, String content, String author, BoardType boardType
 ) {
 }

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -1,9 +1,16 @@
 package org.sopt.dto.request;
 
+import org.sopt.domain.BoardType;
+
 // 게시글 작성 요청 (클라이언트 → 서버)
-// record: 데이터만 담는 불면 객체를 한 줄로 선언 가능!
-// title, content, author를 final 필드로 선언(불변)
-// 세 값을 받는 생성자 자동 생성
-// 각 필드에 대응하는 접근자 메서드 title(), content(), author() 자동 생성
-public record CreatePostRequest(String title, String content, String author) {
+// record: 데이터만 담는 불변 객체를 한 줄로 선언 가능!
+// title, content, author, boardType을 final 필드로 선언(불변)
+// 네 값을 받는 생성자 자동 생성
+// 각 필드에 대응하는 접근자 메서드 title(), content(), author(), boardType() 자동 생성
+public record CreatePostRequest(
+        String title,
+        String content,
+        String author,
+        BoardType boardType
+) {
 }

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -1,15 +1,9 @@
 package org.sopt.dto.request;
 
 // 게시글 작성 요청 (클라이언트 → 서버)
-// 변수 앞에 아무것도 안붙으면 default(해당 패키지 내에서만 접근 가능)
-public class CreatePostRequest {
-    public String title;
-    public String content;
-    public String author;
-
-    public CreatePostRequest(String title, String content, String author) {
-        this.title = title;
-        this.content = content;
-        this.author = author;
-    }
+// record: 데이터만 담는 불면 객체를 한 줄로 선언 가능!
+// title, content, author를 final 필드로 선언(불변)
+// 세 값을 받는 생성자 자동 생성
+// 각 필드에 대응하는 접근자 메서드 title(), content(), author() 자동 생성
+public record CreatePostRequest(String title, String content, String author) {
 }

--- a/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.dto.request;
+
+public record UpdatePostRequest(String title, String content) { }
+

--- a/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
@@ -1,4 +1,5 @@
 package org.sopt.dto.request;
 
-public record UpdatePostRequest(String title, String content) { }
+public record UpdatePostRequest(String title, String content) {
+}
 

--- a/src/main/java/org/sopt/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt/dto/response/ApiResponse.java
@@ -11,6 +11,7 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> success(int code, String message, T data) {
         return new ApiResponse<>(code, message, data);
     }
+
     // 성공 case 2) 기본 200 + 기본 메시지 + 데이터
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse(200, "요청이 성공했습니다.", data);

--- a/src/main/java/org/sopt/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt/dto/response/ApiResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.dto.response;
+
+public record ApiResponse<T>(
+        int code, // HTTP 상태 코드 (200, 201, 404, 500, ...)
+        String message, // 클라에서 확인하는 메시지
+        T data // 실제 페이로드. 실패 시 null
+) {
+    // --성공 응답용 정적 팩토리 메서드--
+    // 성공 case 1) 커스텀 코드 + 메시지 + 데이터
+    // ex: 201, '게시글 등록 완료', createResponse
+    public static <T> ApiResponse<T> success(int code, String message, T data) {
+        return new ApiResponse<>(code, message, data);
+    }
+    // 성공 case 2) 기본 200 + 기본 메시지 + 데이터
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse(200, "요청이 성공했습니다.", data);
+    }
+
+    // --실패 응답용 정적 팩토리 메서드--
+    // ex: ApiResponse.error(404, "게시글을 찾을 수 없습니다. id: 999")
+    public static <T> ApiResponse<T> error(int code, String message) {
+        return new ApiResponse(code, message, null);
+    }
+
+}

--- a/src/main/java/org/sopt/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt/dto/response/ApiResponse.java
@@ -21,5 +21,4 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> error(int code, String message) {
         return new ApiResponse(code, message, null);
     }
-
 }

--- a/src/main/java/org/sopt/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt/dto/response/ApiResponse.java
@@ -1,21 +1,46 @@
 package org.sopt.dto.response;
 
-public record ApiResponse<T>(int code, String message, T data) {
-    // --성공 응답용 정적 팩토리 메서드--
-    // 성공 case 1) 커스텀 코드 + 메시지 + 데이터
-    // ex: 201, '게시글 등록 완료', createResponse
-    public static <T> ApiResponse<T> success(int code, String message, T data) {
-        return new ApiResponse<>(code, message, data);
+import org.sopt.common.ErrorCode;
+import org.sopt.common.SuccessCode;
+
+/**
+ * 모든 API 응답을 감싸는 공통 응답 wrapper
+ * <p>
+ * status  — HTTP 상태 코드 (200, 201, 404, 500 등)
+ * code    — 서버 커스텀 코드 (POST_NOT_FOUND, POST_CREATE_SUCCESS 등)
+ * message — 사용자에게 보여줄 메시지
+ * data    — 실제 페이로드. 에러 응답 시 null
+ * <p>
+ * 성공/실패 시 SuccessCode / ErrorCode enum만 넘겨주면
+ * status, code, message가 한꺼번에 세팅됨
+ */
+public record ApiResponse<T>(int status, String code, String message, T data) {
+
+    // --- 성공 응답용 정적 팩토리 ---
+    // enum + 데이터
+    // ex: ApiResponse.success(SuccessCode.POST_DETAIL_FETCH_SUCCESS, postResponse)
+    public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
+        return new ApiResponse<>(successCode.getStatus().value(),
+                successCode.getCode(),
+                successCode.getMessage(),
+                data);
     }
 
-    // 성공 case 2) 기본 200 + 기본 메시지 + 데이터
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse(200, "요청이 성공했습니다.", data);
+    // 데이터가 없는 성공 응답 (수정/삭제 등)
+    // ex: ApiResponse.success(SuccessCode.POST_DELETE_SUCCESS)
+    public static <T> ApiResponse<T> success(SuccessCode successCode) {
+        return new ApiResponse<>(successCode.getStatus().value(),
+                successCode.getCode(),
+                successCode.getMessage(),
+                null);
     }
 
-    // --실패 응답용 정적 팩토리 메서드--
-    // ex: ApiResponse.error(404, "게시글을 찾을 수 없습니다. id: 999")
-    public static <T> ApiResponse<T> error(int code, String message) {
-        return new ApiResponse(code, message, null);
+    // --- 실패 응답용 정적 팩토리 ---
+    // ex: ApiResponse.error(ErrorCode.POST_NOT_FOUND)
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null);
     }
 }

--- a/src/main/java/org/sopt/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt/dto/response/ApiResponse.java
@@ -1,10 +1,6 @@
 package org.sopt.dto.response;
 
-public record ApiResponse<T>(
-        int code, // HTTP 상태 코드 (200, 201, 404, 500, ...)
-        String message, // 클라에서 확인하는 메시지
-        T data // 실제 페이로드. 실패 시 null
-) {
+public record ApiResponse<T>(int code, String message, T data) {
     // --성공 응답용 정적 팩토리 메서드--
     // 성공 case 1) 커스텀 코드 + 메시지 + 데이터
     // ex: 201, '게시글 등록 완료', createResponse

--- a/src/main/java/org/sopt/dto/response/ApiResponse.java
+++ b/src/main/java/org/sopt/dto/response/ApiResponse.java
@@ -20,27 +20,33 @@ public record ApiResponse<T>(int status, String code, String message, T data) {
     // enum + 데이터
     // ex: ApiResponse.success(SuccessCode.POST_DETAIL_FETCH_SUCCESS, postResponse)
     public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
-        return new ApiResponse<>(successCode.getStatus().value(),
+        return new ApiResponse<>(
+                successCode.getStatus().value(),
                 successCode.getCode(),
                 successCode.getMessage(),
-                data);
+                data
+        );
     }
 
     // 데이터가 없는 성공 응답 (수정/삭제 등)
     // ex: ApiResponse.success(SuccessCode.POST_DELETE_SUCCESS)
     public static <T> ApiResponse<T> success(SuccessCode successCode) {
-        return new ApiResponse<>(successCode.getStatus().value(),
+        return new ApiResponse<>(
+                successCode.getStatus().value(),
                 successCode.getCode(),
                 successCode.getMessage(),
-                null);
+                null
+        );
     }
 
     // --- 실패 응답용 정적 팩토리 ---
     // ex: ApiResponse.error(ErrorCode.POST_NOT_FOUND)
     public static <T> ApiResponse<T> error(ErrorCode errorCode) {
-        return new ApiResponse<>(errorCode.getStatus().value(),
+        return new ApiResponse<>(
+                errorCode.getStatus().value(),
                 errorCode.getCode(),
                 errorCode.getMessage(),
-                null);
+                null
+        );
     }
 }

--- a/src/main/java/org/sopt/dto/response/CreatePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/CreatePostResponse.java
@@ -1,4 +1,5 @@
 package org.sopt.dto.response;
 
 // 게시글 작성 응답 (서버 → 클라이언트)
-public record CreatePostResponse(Long id, String message) { }
+public record CreatePostResponse(Long id, String message) {
+}

--- a/src/main/java/org/sopt/dto/response/CreatePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/CreatePostResponse.java
@@ -1,5 +1,5 @@
 package org.sopt.dto.response;
 
 // 게시글 작성 응답 (서버 → 클라이언트)
-public record CreatePostResponse(Long id, String message) {
+public record CreatePostResponse(Long id) {
 }

--- a/src/main/java/org/sopt/dto/response/CreatePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/CreatePostResponse.java
@@ -1,12 +1,4 @@
 package org.sopt.dto.response;
 
 // 게시글 작성 응답 (서버 → 클라이언트)
-public class CreatePostResponse {
-    public Long id;
-    public String message;
-
-    public CreatePostResponse(Long id, String message) {
-        this.id = id;
-        this.message = message;
-    }
-}
+public record CreatePostResponse(Long id, String message) { }

--- a/src/main/java/org/sopt/dto/response/ErrorResponse.java
+++ b/src/main/java/org/sopt/dto/response/ErrorResponse.java
@@ -1,6 +1,0 @@
-package org.sopt.dto.response;
-
-public record ErrorResponse (
-    String message
-) {
-}

--- a/src/main/java/org/sopt/dto/response/ErrorResponse.java
+++ b/src/main/java/org/sopt/dto/response/ErrorResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.dto.response;
+
+public record ErrorResponse (
+    String message
+) {
+}

--- a/src/main/java/org/sopt/dto/response/PageResponse.java
+++ b/src/main/java/org/sopt/dto/response/PageResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.dto.response;
+
+import java.util.List;
+
+/**
+ * 페이지네이션용 응답 wrapper
+ * 제네릭 T: 페이지 항목 타입
+ * ex: 게시글 페이지네이션이면 PostResponse, 댓글 페이지네이션이면 CommentResposne
+ * <p>
+ * content: 현재 페이지의 실제 데이터 배열
+ * page: 현재 페이지 번호 (0부터 시작)
+ * size: 페이지당 목록 개수
+ * hasNext: 다음 페이지 존재 여부 (무한 스크롤 종료 판단용)
+ *
+ */
+public record PageResponse<T>(List<T> content, int page, int size, boolean hasNext) {
+}

--- a/src/main/java/org/sopt/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostResponse.java
@@ -3,24 +3,15 @@ package org.sopt.dto.response;
 import org.sopt.domain.Post;
 
 // 게시글 조회 응답 (서버 → 클라이언트)
-public record PostResponse(
-        Long id,
-        String title,
-        String content,
-        String author,
-        String createdAt
-) {
-
+public record PostResponse(Long id, String title, String content, String author, String createdAt) {
     // 정적 팩토리 메서드: Post 도메인 객체를 PostResponse로 변환
     // record의 기본 생성자는 선언된 필드를 그대로 받기만 하므로,
     // Post 객체를 하나 받아서 내부 값을 추출하는 로직은 별도의 정적 메서드로 만든다
     public static PostResponse from(Post post) {
-        return new PostResponse(
-                post.getId(),
+        return new PostResponse(post.getId(),
                 post.getTitle(),
                 post.getContent(),
                 post.getAuthor(),
-                post.getCreatedAt()
-        );
+                post.getCreatedAt());
     }
 }

--- a/src/main/java/org/sopt/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostResponse.java
@@ -3,23 +3,24 @@ package org.sopt.dto.response;
 import org.sopt.domain.Post;
 
 // 게시글 조회 응답 (서버 → 클라이언트)
-public class PostResponse {
-    Long id;
-    String title;
-    String content;
-    String author;
-    String createdAt;
+public record PostResponse(
+        Long id,
+        String title,
+        String content,
+        String author,
+        String createdAt
+) {
 
-    public PostResponse(Post post) {
-        this.id = post.getId();
-        this.title = post.getTitle();
-        this.content = post.getContent();
-        this.author = post.getAuthor();
-        this.createdAt = post.getCreatedAt();
-    }
-
-    @Override
-    public String toString() {
-        return "[" + id + "] " + title + " - " + author + " (" + createdAt + ")\n" + content;
+    // 정적 팩토리 메서드: Post 도메인 객체를 PostResponse로 변환
+    // record의 기본 생성자는 선언된 필드를 그대로 받기만 하므로,
+    // Post 객체를 하나 받아서 내부 값을 추출하는 로직은 별도의 정적 메서드로 만든다
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getAuthor(),
+                post.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/org/sopt/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostResponse.java
@@ -1,17 +1,28 @@
 package org.sopt.dto.response;
 
+import org.sopt.domain.BoardType;
 import org.sopt.domain.Post;
 
 // 게시글 조회 응답 (서버 → 클라이언트)
-public record PostResponse(Long id, String title, String content, String author, String createdAt) {
+public record PostResponse(
+        Long id,
+        String title,
+        String content,
+        String author,
+        String createdAt,
+        BoardType boardType
+) {
     // 정적 팩토리 메서드: Post 도메인 객체를 PostResponse로 변환
     // record의 기본 생성자는 선언된 필드를 그대로 받기만 하므로,
     // Post 객체를 하나 받아서 내부 값을 추출하는 로직은 별도의 정적 메서드로 만든다
     public static PostResponse from(Post post) {
-        return new PostResponse(post.getId(),
+        return new PostResponse(
+                post.getId(),
                 post.getTitle(),
                 post.getContent(),
                 post.getAuthor(),
-                post.getCreatedAt());
+                post.getCreatedAt(),
+                post.getBoardType()
+        );
     }
 }

--- a/src/main/java/org/sopt/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostResponse.java
@@ -5,12 +5,7 @@ import org.sopt.domain.Post;
 
 // 게시글 조회 응답 (서버 → 클라이언트)
 public record PostResponse(
-        Long id,
-        String title,
-        String content,
-        String author,
-        String createdAt,
-        BoardType boardType
+        Long id, String title, String content, String author, String createdAt, BoardType boardType
 ) {
     // 정적 팩토리 메서드: Post 도메인 객체를 PostResponse로 변환
     // record의 기본 생성자는 선언된 필드를 그대로 받기만 하므로,

--- a/src/main/java/org/sopt/exception/BusinessException.java
+++ b/src/main/java/org/sopt/exception/BusinessException.java
@@ -1,0 +1,25 @@
+package org.sopt.exception;
+
+import org.sopt.common.ErrorCode;
+
+// Java의 기본 IllegalArgumentException(1주차 커스텀 에러의 부모)에는 ErrorCode를 담을 공간이 없음
+// 따라서 GlobalExceptionHandler의 @ExceptionHandler에서 /common/ErrorCode의 ErrorCode를 받아
+// 적절한 에러 형식(status, code, message)을 구현해 클라에게 넘겨주려면 커스텀 에러를 담는 별도의 클래스 필요
+public class BusinessException extends RuntimeException {
+
+    // 서버 커스텀 에러코드(status, code, message)를 담는 필드
+    // -> BusinessException은 RuntimeException의 message 필드와 자신의 errorCode 필드를 가지는 클래스가 됨
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        // RuntimeException의 부모인 Throwable 내부에 detailMessage 필드가 있는데,
+        // 명시적으로 super()에 메시지를 전달하지 않으면 detailMessage가 null이 되어
+        // e.getMessage()의 결과가 null이 된다
+        super(errorCode.getMessage()); // e.message() 호출 대비 -> RuntimeException의 메시지도 ErrorCode에서 뽑아둠
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 // @RestControllerAdvice:
 // 모든 @RestController에서 발생한 예외를 감시하는 '전역 예외 처리자'
@@ -24,11 +25,21 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(errorCode.getStatus()).body(ApiResponse.error(errorCode));
     }
 
-    // Jackson이 JSON -> 객체 변환 실패 시 발생 (잘못된 enum값, 필수 필드 누락, 타입 불일치 등)
-    // ex: 잘못된 BoardType 전달 -> 400 Bad Request
+    // Jackson이 HTTP Body 파싱 실패 시 발생
+    // JSON 문법 자체가 깨짐, 잘못된 enum값으로 Json -> Java 객체변환 실패, 필수 필드 누락, 타입 불일치
+    // ex: 잘못된 BoardType 전달 -> Java enum 객체로 변환 실패 -> 400 Bad Request
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleMessageNotReadable(
-            HttpMessageNotReadableException e) {
+            HttpMessageNotReadableException e
+    ) {
+        return ResponseEntity.status(ErrorCode.BAD_REQUEST.getStatus())
+                .body(ApiResponse.error(ErrorCode.BAD_REQUEST));
+    }
+
+    // HTTP Body 파싱 실패가 아니라, Query/Path 변수 타입 변환 실패
+    // @RequestParam, @PathVariable에 잘못된 값이 전달됐을 때 발생
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
         return ResponseEntity.status(ErrorCode.BAD_REQUEST.getStatus())
                 .body(ApiResponse.error(ErrorCode.BAD_REQUEST));
     }

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package org.sopt.exception;
+
+import org.sopt.dto.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+// @RestControllerAdvice:
+// 모든 @RestController에서 발생한 예외를 감시하는 '전역 예외 처리자'
+// 여기 정의한 @ExceptionHandler 메서드가 해당 예외를 가로채서 응답으로 변환.
+// (@ControllerAdvice + @ResponseBody의 합본이라 반환값이 JSON으로 자동 변환됨)
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // PostNotFoundException 발생 시 호출
+    // Service에서 "없는 id로 조회/수정/삭제 시도"했을 때 이 핸들러가 작동
+    // → 404 Not Found + 에러 메시지 반환
+    @ExceptionHandler(PostNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePostNotFound(PostNotFoundException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+    // IllegalArgumentException 발생 시 호출
+    // PostValidator가 제목/내용 검증 실패 시 던지는 예외
+    // → 400 Bad Request (클라이언트가 잘못된 요청을 보냄).
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+    // 위에서 안 잡힌 모든 예외의 마지막 안전망
+    // Spring은 더 구체적인 핸들러를 우선 매칭하므로,
+    // 이 핸들러는 "예상 못한 버그나 시스템 오류"가 터졌을 때만 실행됨
+    // → 500 Internal Server Error + 일반화된 메시지
+    //   (보안상 e.getMessage()를 그대로 노출하지 않고 일반 메시지 반환)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse("서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.sopt.exception;
 
+import org.sopt.common.ErrorCode;
 import org.sopt.dto.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,32 +15,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 // ApiResponse<Void>로 Void 타입을 사용해 ApiResponse의 data 필드가 비어있음을 알려줌
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    // PostNotFoundException 발생 시 호출
-    // Service에서 "없는 id로 조회/수정/삭제 시도"했을 때 이 핸들러가 작동
-    // → 404 Not Found + 에러 메시지 반환
-    @ExceptionHandler(PostNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error(404, e.getMessage()));
-    }
-
-    // IllegalArgumentException 발생 시 호출
-    // PostValidator가 제목/내용 검증 실패 시 던지는 예외
-    // → 400 Bad Request (클라이언트가 잘못된 요청을 보냄).
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(400, e.getMessage()));
+    // BusinessException + 그 자식(PostNotFoundException 등) 전부 여기서 처리
+    // 예외가 들고 있는 ErrorCode를 꺼내 상태/코드/메시지 일괄 세팅 -> 클라에 반환할 형식으로 변환해 반환
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(errorCode));
     }
 
     // 위에서 안 잡힌 모든 예외의 마지막 안전망
     // Spring은 더 구체적인 핸들러를 우선 매칭하므로,
     // 이 핸들러는 "예상 못한 버그나 시스템 오류"가 터졌을 때만 실행됨
     // → 500 Internal Server Error + 일반화된 메시지
-    //   (보안상 e.getMessage()를 그대로 노출하지 않고 일반 메시지 반환)
+    // (보안상 e.getMessage()를 그대로 노출하지 않고 일반 메시지 반환)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error(500, "서버 내부 오류가 발생했습니다."));
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 // 여기 정의한 @ExceptionHandler 메서드가 해당 예외를 가로채서 응답으로 변환.
 // (@ControllerAdvice + @ResponseBody라서 반환값이 JSON으로 자동 변환됨)
 // +) 에러 응답이나 update/delete 성공 응답은 반환할 데이터가 없음 ->
-// ApiResponse<Void>로 Void 타입을 사용해 이 자리가 비어있음을 알려줌
+// ApiResponse<Void>로 Void 타입을 사용해 ApiResponse의 data 필드가 비어있음을 알려줌
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     // PostNotFoundException 발생 시 호출

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -19,8 +19,7 @@ public class GlobalExceptionHandler {
     // → 404 Not Found + 에러 메시지 반환
     @ExceptionHandler(PostNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.error(404, e.getMessage()));
     }
 
@@ -29,8 +28,7 @@ public class GlobalExceptionHandler {
     // → 400 Bad Request (클라이언트가 잘못된 요청을 보냄).
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error(400, e.getMessage()));
     }
 
@@ -41,8 +39,7 @@ public class GlobalExceptionHandler {
     //   (보안상 e.getMessage()를 그대로 노출하지 않고 일반 메시지 반환)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error(500, "서버 내부 오류가 발생했습니다."));
     }
 }

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package org.sopt.exception;
 
-import org.sopt.dto.response.ErrorResponse;
+import org.sopt.dto.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,27 +9,29 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 // @RestControllerAdvice:
 // 모든 @RestController에서 발생한 예외를 감시하는 '전역 예외 처리자'
 // 여기 정의한 @ExceptionHandler 메서드가 해당 예외를 가로채서 응답으로 변환.
-// (@ControllerAdvice + @ResponseBody의 합본이라 반환값이 JSON으로 자동 변환됨)
+// (@ControllerAdvice + @ResponseBody라서 반환값이 JSON으로 자동 변환됨)
+// +) 에러 응답이나 update/delete 성공 응답은 반환할 데이터가 없음 ->
+// ApiResponse<Void>로 Void 타입을 사용해 이 자리가 비어있음을 알려줌
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     // PostNotFoundException 발생 시 호출
     // Service에서 "없는 id로 조회/수정/삭제 시도"했을 때 이 핸들러가 작동
     // → 404 Not Found + 에러 메시지 반환
     @ExceptionHandler(PostNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handlePostNotFound(PostNotFoundException e) {
+    public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse(e.getMessage()));
+                .body(ApiResponse.error(404, e.getMessage()));
     }
 
     // IllegalArgumentException 발생 시 호출
     // PostValidator가 제목/내용 검증 실패 시 던지는 예외
     // → 400 Bad Request (클라이언트가 잘못된 요청을 보냄).
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(e.getMessage()));
+                .body(ApiResponse.error(400, e.getMessage()));
     }
 
     // 위에서 안 잡힌 모든 예외의 마지막 안전망
@@ -38,9 +40,9 @@ public class GlobalExceptionHandler {
     // → 500 Internal Server Error + 일반화된 메시지
     //   (보안상 e.getMessage()를 그대로 노출하지 않고 일반 메시지 반환)
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse("서버 내부 오류가 발생했습니다."));
+                .body(ApiResponse.error(500, "서버 내부 오류가 발생했습니다."));
     }
 }

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -2,8 +2,8 @@ package org.sopt.exception;
 
 import org.sopt.common.ErrorCode;
 import org.sopt.dto.response.ApiResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,7 +20,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(errorCode));
+        // 상태 코드는 ErrorCode가 갖고 있는 값 사용 (POST_NOT_FOUND면 404, TITLE_REQUIRED면 400 등)
+        return ResponseEntity.status(errorCode.getStatus()).body(ApiResponse.error(errorCode));
+    }
+
+    // Jackson이 JSON -> 객체 변환 실패 시 발생 (잘못된 enum값, 필수 필드 누락, 타입 불일치 등)
+    // ex: 잘못된 BoardType 전달 -> 400 Bad Request
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMessageNotReadable(
+            HttpMessageNotReadableException e) {
+        return ResponseEntity.status(ErrorCode.BAD_REQUEST.getStatus())
+                .body(ApiResponse.error(ErrorCode.BAD_REQUEST));
     }
 
     // 위에서 안 잡힌 모든 예외의 마지막 안전망
@@ -30,7 +40,8 @@ public class GlobalExceptionHandler {
     // (보안상 e.getMessage()를 그대로 노출하지 않고 일반 메시지 반환)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
     }
+
 }

--- a/src/main/java/org/sopt/exception/PostNotFoundException.java
+++ b/src/main/java/org/sopt/exception/PostNotFoundException.java
@@ -2,6 +2,8 @@ package org.sopt.exception;
 
 import org.sopt.common.ErrorCode;
 
+// PostNotFoundException도 그냥 BusinessException으로 처리 가능함
+// 하지만 중요한 도메인 예외는 별도의 클래스로 둔다고 함(?) -- claude
 public class PostNotFoundException extends BusinessException {
     public PostNotFoundException() {
         // 부모(BusinessException) 생성자에 ErrorCode를 넘김

--- a/src/main/java/org/sopt/exception/PostNotFoundException.java
+++ b/src/main/java/org/sopt/exception/PostNotFoundException.java
@@ -1,7 +1,13 @@
 package org.sopt.exception;
 
-public class PostNotFoundException extends RuntimeException {
-    public PostNotFoundException(Long id) {
-        super("존재하지 않는 게시글입니다. id: " + id);
+import org.sopt.common.ErrorCode;
+
+public class PostNotFoundException extends BusinessException {
+    public PostNotFoundException() {
+        // 부모(BusinessException) 생성자에 ErrorCode를 넘김
+        // BusinessException이 다시 super(errorCode.getMessage())를 실행해
+        // BusinessException의 부모(RuntimeException)의 부모(Throwable)의 detailMessage 세팅
+        // -> e.getMessage()로 POST_NOT_FOUND enum의 message 필드 접근 가능
+        super(ErrorCode.POST_NOT_FOUND);
     }
 }

--- a/src/main/java/org/sopt/repository/InMemoryPostRepository.java
+++ b/src/main/java/org/sopt/repository/InMemoryPostRepository.java
@@ -1,0 +1,46 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Post;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * PostRepository 인터페이스의 메모리(ArrayList) 기반 구현체
+ *
+ * @Repository : Spring이 이 클래스를 Bean으로 등록해줌 -- Spring DI(Dependency Injection)
+ * PostService가 PostRepository 타입으로 주입 요청하면 Spring이 이 구현체를 주입
+ */
+@Repository
+public class InMemoryPostRepository implements PostRepository {
+
+    private final List<Post> postList = new ArrayList<>();
+    private Long nextId = 1L;
+
+    @Override
+    public Post save(Post post) {
+        postList.add(post);
+        return post;
+    }
+
+    @Override
+    public List<Post> findAll() {
+        return postList;
+    }
+
+    @Override
+    public Post findById(Long id) {
+        return postList.stream().filter(p -> p.getId().equals(id)).findFirst().orElse(null);
+    }
+
+    @Override
+    public boolean deleteById(Long id) {
+        return postList.removeIf(p -> p.getId().equals(id));
+    }
+
+    @Override
+    public Long generateId() {
+        return nextId++;
+    }
+}

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -2,9 +2,15 @@ package org.sopt.repository;
 
 import org.sopt.domain.Post;
 
+import org.springframework.stereotype.Repository;
+
 import java.util.ArrayList;
 import java.util.List;
 
+// @Repository -> Spring이 이 클래스를 Bean으로 등록하고 관리함
+// 앱 시작 시 Spring이 PostRepository 인스턴스를 만들어 Container에 보관
+// 이후 PostService 등이 이 인스턴스를 주입받아 사용
+@Repository
 public class PostRepository {
     private final List<Post> postList = new ArrayList<>();
     private Long nextId = 1L;

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -1,41 +1,36 @@
 package org.sopt.repository;
 
 import org.sopt.domain.Post;
-import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
 import java.util.List;
 
-// @Repository -> Spring이 이 클래스를 Bean으로 등록하고 관리함
-// 앱 시작 시 Spring이 PostRepository 인스턴스를 만들어 Container에 보관
-// 이후 PostService 등이 이 인스턴스를 주입받아 사용
-@Repository
-public class PostRepository {
-    private final List<Post> postList = new ArrayList<>();
-    private Long nextId = 1L;
+/**
+ * 게시글 저장소 추상화
+ * <p>
+ * 상위 모듈(PostService)은 이 인터페이스에만 의존함으로써 DIP를 충족
+ * <p>
+ * +) 기존에는 PostService가 PostRepository 객체를 직접 참조함
+ * PostRepository는 Bean으로 등록되긴 했지만 구체 클래스 그 자체
+ * -> 따라서 Spring DI(Dependency Injection)은 적용되지만 SOLID 원칙인 DIP는 적용되지 않음
+ * => PostRepository를 interface로 바꾸고 이를 구현한 구현체(InMemoryPostRepository 등)를 선언하고
+ * PostService에서는 PostRepository 인터페이스를 참조하도록 하면 DIP 적용 완료!
+ * <p>
+ * 구현체는 여러 개일 수 있음:
+ * - InMemoryPostRepository: ArrayList 기반
+ * - DataBasePostRepository: DB 기반(3주차에 적용)
+ *
+ * @Repository 어노테이션은 인터페이스가 아니라 구현체에 붙음 (인터페이스는 인스턴스화 불가).
+ */
+public interface PostRepository {
 
-    public Post save(Post post) {
-        postList.add(post);
-        return post;
-    }
+    Post save(Post post);
 
-    public List<Post> findAll() {
-        return postList;
-    }
+    List<Post> findAll();
 
-    // TODO: 반환값 optional
-    public Post findById(Long id) {
-        return postList.stream()
-                .filter(p -> p.getId().equals(id))
-                .findFirst()
-                .orElse(null);
-    }
+    // TODO: 반환값 Optional<Post>로 전환 고려
+    Post findById(Long id);
 
-    public boolean deleteById(Long id) {
-        return postList.removeIf(p -> p.getId().equals(id));
-    }
+    boolean deleteById(Long id);
 
-    public Long generateId() {
-        return nextId++;
-    }
+    Long generateId();
 }

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -1,7 +1,6 @@
 package org.sopt.repository;
 
 import org.sopt.domain.Post;
-
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -24,6 +23,7 @@ public class PostRepository {
         return postList;
     }
 
+    // TODO: 반환값 optional
     public Post findById(Long id) {
         return postList.stream()
                 .filter(p -> p.getId().equals(id))

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -35,7 +35,7 @@ public class PostService {
                 request.content());
         String createdAt = java.time.LocalDateTime.now().toString();
         Post post = new Post(postRepository.generateId(), request.title(),
-                request.content(), request.author(), createdAt);
+                request.content(), request.author(), createdAt, request.boardType());
         postRepository.save(post);
         return new CreatePostResponse(post.getId(), "게시글 등록 완료!");
     }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -1,14 +1,15 @@
 package org.sopt.service;
 
+import org.sopt.domain.BoardType;
 import org.sopt.domain.Post;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.CreatePostResponse;
+import org.sopt.dto.response.PageResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.repository.PostRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service // Bean으로 관리
@@ -31,24 +32,46 @@ public class PostService {
     // CREATE
     public CreatePostResponse createPost(CreatePostRequest request) {
         // request가 record이므로 request.title()과 같이 필드값 가져옴
-        postValidator.validateTitleAndContent(request.title(),
-                request.content());
+        postValidator.validateTitleAndContent(request.title(), request.content());
         String createdAt = java.time.LocalDateTime.now().toString();
-        Post post = new Post(postRepository.generateId(), request.title(),
-                request.content(), request.author(), createdAt, request.boardType());
+        Post post = new Post(postRepository.generateId(),
+                request.title(),
+                request.content(),
+                request.author(),
+                createdAt,
+                request.boardType());
         postRepository.save(post);
         return new CreatePostResponse(post.getId(), "게시글 등록 완료!");
     }
 
     // READ - 전체
-    public List<PostResponse> getAllPosts() {
-        List<Post> posts = postRepository.findAll();
-        List<PostResponse> responses = new ArrayList<>();
-        for (Post post : posts) {
-            // new PostResponse(post) -> PostResponse.from(post)로 변경
-            responses.add(PostResponse.from(post));
-        }
-        return responses;
+    public PageResponse<PostResponse> getAllPosts(int page, int size, BoardType boardType) {
+        // 1. 전체 게시글 가져오기
+        List<Post> all = postRepository.findAll();
+
+        // 2. boardType 필터링 (null이면 전체, 아니면 일치하는 게시글만)
+        // boardType == null이면 filter() 조건이 true가 되어 전체 게시글 반환
+        // boardType == 'HOT'이면 boardType == null가 false이므로
+        // p.getBoardType() == boardType을 만족하는 리스트만 반환
+        List<Post> filtered = all.stream()
+                .filter(p -> boardType == null || p.getBoardType() == boardType)
+                .toList();
+
+        // 3. 페이지 슬라이싱
+        int from = page * size;
+        int to = Math.min(from + size, filtered.size());
+        List<Post> pageSlice = from >= filtered.size() ? List.of() : filtered.subList(from, to);
+
+        // 4. DTO 반환
+        List<PostResponse> content = pageSlice.stream().map(PostResponse::from).toList();
+
+        // 5. hasNext 계산 (다음 페이지 존재 여부)
+        boolean hasNext = to < filtered.size();
+
+        // 6. PageResponse 생성
+        // 요청/응답 순간에만 존재, 불변(상태 없음), 매 요청마다 다른 데이터로 새로 만들어지는게 정상, Spring이 관리할 필요 없음
+        // => Spring DI의 관리 대상 X, new 사용하는게 당연함
+        return new PageResponse<PostResponse>(content, page, size, hasNext);
     }
 
     // READ - 단건
@@ -60,8 +83,7 @@ public class PostService {
     // UPDATE
     public void updatePost(Long id, UpdatePostRequest request) {
         Post post = postValidator.validatePostExists(postRepository.findById(id));
-        postValidator.validateTitleAndContent(request.title(),
-                request.content());
+        postValidator.validateTitleAndContent(request.title(), request.content());
         post.update(request.title(), request.content());
     }
 

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -53,15 +53,13 @@ public class PostService {
 
     // READ - 단건
     public PostResponse getPost(Long id) {
-        Post post = postValidator.validatePostExists(
-                postRepository.findById(id), id);
+        Post post = postValidator.validatePostExists(postRepository.findById(id));
         return PostResponse.from(post);
     }
 
     // UPDATE
     public void updatePost(Long id, UpdatePostRequest request) {
-        Post post = postValidator.validatePostExists(
-                postRepository.findById(id), id);
+        Post post = postValidator.validatePostExists(postRepository.findById(id));
         postValidator.validateTitleAndContent(request.title(),
                 request.content());
         post.update(request.title(), request.content());
@@ -69,7 +67,7 @@ public class PostService {
 
     // DELETE
     public void deletePost(Long id) {
-        postValidator.validatePostExists(postRepository.findById(id), id);
+        postValidator.validatePostExists(postRepository.findById(id));
         postRepository.deleteById(id);
     }
 }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
-@Service
+@Service // Bean으로 관리
 public class PostService {
     // 생성자에서 주입받을 참조만 선언해둠
     // Spring이 PostService 생성자를 보고 파라미터 타입이 PostRepository, PostValidator임을 확인
     // -> 이미 Bean으로 등록된 인스턴스를 찾아서 자동으로 넣어줌, '생성자 주입'
-    // private final -> 불변성 보장
+    // private final -> 불변성 보장 (+: final은 이 주소가 바뀌면 안된다는 뜻이지 객체의 내부는 변경 가능)
     private final PostRepository postRepository;
     private final PostValidator postValidator;
 

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -31,15 +31,11 @@ public class PostService {
     // CREATE
     public CreatePostResponse createPost(CreatePostRequest request) {
         // request가 record이므로 request.title()과 같이 필드값 가져옴
-        postValidator.validateTitleAndContent(request.title(), request.content());
+        postValidator.validateTitleAndContent(request.title(),
+                request.content());
         String createdAt = java.time.LocalDateTime.now().toString();
-        Post post = new Post(
-                postRepository.generateId(),
-                request.title(),
-                request.content(),
-                request.author(),
-                createdAt
-        );
+        Post post = new Post(postRepository.generateId(), request.title(),
+                request.content(), request.author(), createdAt);
         postRepository.save(post);
         return new CreatePostResponse(post.getId(), "게시글 등록 완료!");
     }
@@ -57,14 +53,17 @@ public class PostService {
 
     // READ - 단건
     public PostResponse getPost(Long id) {
-        Post post = postValidator.validatePostExists(postRepository.findById(id), id);
+        Post post = postValidator.validatePostExists(
+                postRepository.findById(id), id);
         return PostResponse.from(post);
     }
 
     // UPDATE
     public void updatePost(Long id, UpdatePostRequest request) {
-        Post post = postValidator.validatePostExists(postRepository.findById(id), id);
-        postValidator.validateTitleAndContent(request.title(), request.content());
+        Post post = postValidator.validatePostExists(
+                postRepository.findById(id), id);
+        postValidator.validateTitleAndContent(request.title(),
+                request.content());
         post.update(request.title(), request.content());
     }
 

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -43,7 +43,7 @@ public class PostService {
                 request.boardType()
         );
         postRepository.save(post);
-        return new CreatePostResponse(post.getId(), "게시글 등록 완료!");
+        return new CreatePostResponse(post.getId());
     }
 
     // READ - 전체

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -34,12 +34,14 @@ public class PostService {
         // request가 record이므로 request.title()과 같이 필드값 가져옴
         postValidator.validateTitleAndContent(request.title(), request.content());
         String createdAt = java.time.LocalDateTime.now().toString();
-        Post post = new Post(postRepository.generateId(),
+        Post post = new Post(
+                postRepository.generateId(),
                 request.title(),
                 request.content(),
                 request.author(),
                 createdAt,
-                request.boardType());
+                request.boardType()
+        );
         postRepository.save(post);
         return new CreatePostResponse(post.getId(), "게시글 등록 완료!");
     }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -5,13 +5,27 @@ import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.repository.PostRepository;
+import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Service
 public class PostService {
-    private final PostRepository postRepository = new PostRepository();
-    private final PostValidator postValidator = new PostValidator();
+    // 생성자에서 주입받을 참조만 선언해둠
+    // Spring이 PostService 생성자를 보고 파라미터 타입이 PostRepository, PostValidator임을 확인
+    // -> 이미 Bean으로 등록된 인스턴스를 찾아서 자동으로 넣어줌, '생성자 주입'
+    // private final -> 불변성 보장
+    private final PostRepository postRepository;
+    private final PostValidator postValidator;
+
+    // 생성자 주입 코드
+    // Spring이 PostService 인스턴스 생성 시 Bean에서 PostRepository와 PostValidator 찾아서
+    // 생성자의 파라미터에 자동 주입해줌. PostService가 스스로 new X
+    public PostService(PostRepository postRepository, PostValidator postValidator) {
+        this.postRepository = postRepository;
+        this.postValidator = postValidator;
+    }
 
     // CREATE
     public CreatePostResponse createPost(CreatePostRequest request) {

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -2,6 +2,7 @@ package org.sopt.service;
 
 import org.sopt.domain.Post;
 import org.sopt.dto.request.CreatePostRequest;
+import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.repository.PostRepository;
@@ -29,9 +30,16 @@ public class PostService {
 
     // CREATE
     public CreatePostResponse createPost(CreatePostRequest request) {
-        postValidator.validateTitleAndContent(request.title, request.content);
+        // request가 record이므로 request.title()과 같이 필드값 가져옴
+        postValidator.validateTitleAndContent(request.title(), request.content());
         String createdAt = java.time.LocalDateTime.now().toString();
-        Post post = new Post(postRepository.generateId(), request.title, request.content, request.author, createdAt);
+        Post post = new Post(
+                postRepository.generateId(),
+                request.title(),
+                request.content(),
+                request.author(),
+                createdAt
+        );
         postRepository.save(post);
         return new CreatePostResponse(post.getId(), "게시글 등록 완료!");
     }
@@ -41,7 +49,8 @@ public class PostService {
         List<Post> posts = postRepository.findAll();
         List<PostResponse> responses = new ArrayList<>();
         for (Post post : posts) {
-            responses.add(new PostResponse(post));
+            // new PostResponse(post) -> PostResponse.from(post)로 변경
+            responses.add(PostResponse.from(post));
         }
         return responses;
     }
@@ -49,14 +58,14 @@ public class PostService {
     // READ - 단건
     public PostResponse getPost(Long id) {
         Post post = postValidator.validatePostExists(postRepository.findById(id), id);
-        return new PostResponse(post);
+        return PostResponse.from(post);
     }
 
     // UPDATE
-    public void updatePost(Long id, String newTitle, String newContent) {
+    public void updatePost(Long id, UpdatePostRequest request) {
         Post post = postValidator.validatePostExists(postRepository.findById(id), id);
-        postValidator.validateTitleAndContent(newTitle, newContent);
-        post.update(newTitle, newContent);
+        postValidator.validateTitleAndContent(request.title(), request.content());
+        post.update(request.title(), request.content());
     }
 
     // DELETE

--- a/src/main/java/org/sopt/service/PostValidator.java
+++ b/src/main/java/org/sopt/service/PostValidator.java
@@ -2,7 +2,14 @@ package org.sopt.service;
 
 import org.sopt.domain.Post;
 import org.sopt.exception.PostNotFoundException;
+import org.springframework.stereotype.Component;
 
+// @Repository, @Service, @Controller 등의 어노테이션이 있음
+// Validator는 저장소/Service/Controller 모두 아님 -> 범용 Bean으로
+// 등록할 때 쓰는 @Component가 적절, 기능은 다른 어노테이션과 동일(Spring Bean으로 등록, 필요한 곳에 주입)
+// PostService가 new PostValidator()를 버리고 생성자 주입으로 PostValidator를 받으려면
+// PostValidator도 Spring이 관리하는 Bean이어야 함
+@Component
 public class PostValidator {
 
     private static final int MAX_TITLE_LENGTH = 50;

--- a/src/main/java/org/sopt/service/PostValidator.java
+++ b/src/main/java/org/sopt/service/PostValidator.java
@@ -20,13 +20,15 @@ public class PostValidator {
             throw new IllegalArgumentException("제목은 필수입니다!");
         }
         if (title.length() > MAX_TITLE_LENGTH) {
-            throw new IllegalArgumentException("제목은 " + MAX_TITLE_LENGTH + "자 이하여야 합니다!");
+            throw new IllegalArgumentException(
+                    "제목은 " + MAX_TITLE_LENGTH + "자 이하여야 합니다!");
         }
         if (content == null || content.isBlank()) {
             throw new IllegalArgumentException("내용은 필수입니다!");
         }
         if (content.length() > MAX_CONTENT_LENGTH) {
-            throw new IllegalArgumentException("내용은 " + MAX_CONTENT_LENGTH + "자 이하여야 합니다!");
+            throw new IllegalArgumentException(
+                    "내용은 " + MAX_CONTENT_LENGTH + "자 이하여야 합니다!");
         }
     }
 

--- a/src/main/java/org/sopt/service/PostValidator.java
+++ b/src/main/java/org/sopt/service/PostValidator.java
@@ -1,6 +1,8 @@
 package org.sopt.service;
 
+import org.sopt.common.ErrorCode;
 import org.sopt.domain.Post;
+import org.sopt.exception.BusinessException;
 import org.sopt.exception.PostNotFoundException;
 import org.springframework.stereotype.Component;
 
@@ -17,24 +19,19 @@ public class PostValidator {
 
     public void validateTitleAndContent(String title, String content) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("제목은 필수입니다!");
+            throw new BusinessException(ErrorCode.TITLE_REQUIRED);
         }
         if (title.length() > MAX_TITLE_LENGTH) {
-            throw new IllegalArgumentException(
-                    "제목은 " + MAX_TITLE_LENGTH + "자 이하여야 합니다!");
-        }
-        if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("내용은 필수입니다!");
+            throw new BusinessException(ErrorCode.TITLE_TOO_LONG);
         }
         if (content.length() > MAX_CONTENT_LENGTH) {
-            throw new IllegalArgumentException(
-                    "내용은 " + MAX_CONTENT_LENGTH + "자 이하여야 합니다!");
+            throw new BusinessException(ErrorCode.CONTENT_TOO_LONG);
         }
     }
 
-    public Post validatePostExists(Post post, Long id) {
+    public Post validatePostExists(Post post) {
         if (post == null) {
-            throw new PostNotFoundException(id);
+            throw new PostNotFoundException();
         }
         return post;
     }


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] 세미나에서 TODO로 남겨둔 Read(전체) / Read(단건) / Update / Delete Controller, Service를 완성해주세요
- [x] 에브리타임 화면설계서를 와인잔조 조원들과 함께 보고, 게시글 목록 / 상세 / 작성 / 수정 / 삭제 API에 대한 API 명세서를 노션으로 작성해주세요. Method, URL, Request Body, Response Body, 상태 코드를 포함해주세요. 노션 링크를 PR에 첨부해주세요
- [x] PostNotFoundException 커스텀 예외 클래스를 만들고, @RestControllerAdvice로 적절한 HTTP 상태 코드와 함께 응답하도록 구현해주세요. 에러 코드 체계도 함께 고민해봐요 (예: POST_001: 게시글을 찾을 수 없습니다)
- [x] ApiResponse<T> 공통 응답 객체를 설계하고, 모든 API의 성공/실패 응답이 일관된 형식을 갖도록 적용해주세요
- [x] 완성한 API 전체를 Postman으로 테스트하고, 각 API의 성공/실패 응답 화면을 캡처해서 PR에 첨부해주세요

<br>

### 심화과제
- [x] 게시글 목록 조회 API에 Pagination을 적용해주세요. page와 size 쿼리 파라미터를 받아서 해당 페이지의 게시글 목록을 반환하도록 구현해주세요. (예: GET /posts?page=0&size=10)
- [x] PostRepository를 인터페이스로 추출하고, 기존 구현체를 InMemoryPostRepository로 이름을 바꿔 구현해주세요. PostService가 인터페이스에만 의존하도록 수정하고 Spring DI로 주입받도록 해주세요
- [x] 에러 코드를 enum으로 관리해보세요. ErrorCode enum에 상태 코드와 메시지를 함께 정의하고, GlobalExceptionHandler가 이를 활용하도록 구성해주세요
- [x] 게시판 종류(FREE, HOT, SECRET)를 boardType 필드로 추가하고, 게시판 종류별로 게시글을 조회하는 API를 구현해주세요. boardType은 enum으로 정의해주세요

<br>

### API 명세서

[API 명세서](https://pumped-rambutan-22d.notion.site/API-34bb0ec89ac98013adbbfb2bf4f041e7?pvs=74)


### **구현한 내용에 대해서 설명해주세요**

1. **Repository 인터페이스 추출 — Spring DI와 DIP**
    - 기존에 PostService가 PostRepository 구체 클래스에 의존하는 구조였음
    - PostRepository에 @Repository가 붙어 Bean으로 등록되므로 Spring DI는 이미 적용된 상태
    - 하지만 구체 클래스 자체에 의존하고 있어 DIP는 미적용인 상태였음
    - 해결: PostRepository를 인터페이스로 전환하고 구현체 InMemoryPostRepository를 분리함. PostService는 인터페이스에만 의존하게 되어 DIP 충족
    
    ⇒ Spring DI는 객체 생성 관리 주체 문제고, DIP는 "무엇에 의존하느냐"의 문제(Dependency Inversion, Dependency Injection 구분 필요)
    

1. **API 명세서 작성**
    
    **리소스 단위로 명세 작성**
    
    - 화면 별 명세 쪼개기 vs 리소스 단위(Post, Comment 등) 명세 쪼개기 → 리소스 단위로 정리하는 게 맞다고 판단
    - 같은 API가 여러 화면에서 재사용될 수 있고, 화면 기획은 자주 바뀌지만 리소스 구조는 상대적으로 안정적이기 때문
    
     **해시태그 설계**
    
    - 화면설계서에 해시태그가 본문에 섞여있는 형태 (해시태그만 별도로 입력하는 UI가 없음) ⇒ 본문으로부터 해시태그 파싱과 저장을 어떻게 할지 고민함
    - 파싱 주체: 클라 파싱은 플랫폼마다(iOS/Android/Web) 규칙이 어긋날 위험 + 클라가 보내는 해시태그 배열이 의도적으로 **조작**될 수 있음. 또한 해시태그 관리 관련 변경사항 발생 시 서버만 수정으로 끝날 수 있다
        
        ⇒ **서버 파싱이 적절**할 것 같다고 판단
        
    - 한 게시글이 여러 해시태그를 갖고, 한 해시태그가 여러 게시글에 쓰임 → 해시태그를 어떻게 관리할지 고민해봤는데, 이런 관계를 ‘**N:M 관계 / 다대다 관계**’라고 하며, 해시태그 관리를 위해서는 Post ─ PostHashtag ─ Hashtag **중간 조인 테이블**이 필요하다고 함. Hashtag를 **별도 엔티티**로 빼야 검색/통계/트렌드 기능이 가능하다!
        
        또한 해시태그 전용 API 필요 — 서버에서 해시태그를 저장하는 것만으로는 부족, 자동완성(GET /hashtags/search), 해시태그별 게시글(GET /hashtags/{name}/posts),
        트렌딩(GET /hashtags/trending) 등 별도 엔드포인트 설계가 필요함을 알게됨
        
        +) 해시태그는 이번 과제 범위(Post CRUD)에서 벗어나 어떻게 관리해야될지 알아보기까지만 했습니다ㅎㅎ
        
    
    **게시글 작성 POST 응답 설계**
    
    - 최소한의 응답만(id만) vs 전체(생성된 게시글 데이터 전부) 중 고민
    - 화면설계서상 "작성 완료 → 게시글 목록으로 복귀" 플로우이므로, 복귀 후 목록이 다시 재조회되므로 작성 응답에 상세 데이터까지 싣지 않아도 된다고 판단
        
        ⇒ id만 내려주는 최소 응답으로 결정
        
    
    **ApiResponse 공통 응답 구성**
    
    - 최종 구조: `status` + `code` + `message` + `data`
        - status: HTTP 상태 코드 (200, 404 등)
        - code: 서버 커스텀 코드 (POST_NOT_FOUND, POST_CREATE_SUCCESS 등)
    - ErrorCode / SuccessCode를 enum으로 관리하고, enum 자체가 status + code + message를 들고 있음
    - Controller는 `ApiResponse.success(SuccessCode.POST_LIST_FETCH_SUCCESS, data)` / `ApiResponse.error(ErrorCode.POST_NOT_FOUND)` 처럼 enum 하나만 넘기면 클라에 넘길 응답 생성 완료!
    - enum의 name() 메서드를 활용해 enum 상수명(POST_NOT_FOUND)이 `code` 문자열("POST_NOT_FOUND")이 되도록 함 → 두 값을 따로 선언할 필요가 없어져 관리가 용이해짐
    
2. **에러 코드 체계 & 예외 처리**
    - BusinessException 추가: 비즈니스 로직에서 발생하는 예외의 공통 부모 클래스, RuntimeException을 상속함
        
        예외를 던지는 곳에서는 `throw new BusinessException(ErrorCode.POST_NOT_FOUND)` 와 같이 에러를 던지면 됨
        
    - 다음과 같이 선언해 GlobalExceptionHandler에서 비즈니스 로직에서 발생하는 에러 일괄 처리
        
        ```java
        @RestControllerAdvice
        public class GlobalExceptionHandler {
            @ExceptionHandler(BusinessException.class)
            public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
                ErrorCode errorCode = e.getErrorCode();
                return ResponseEntity.status(errorCode.getStatus()).body(ApiResponse.error(errorCode));
            }
        ```
        

1. **HTTP 입력 변환 계층**
    
    클라이언트 요청 → Java 객체 변환을 두 곳에서 담당
    
    - @RequestBody: JSON Body를 Java 객체로 변환, **Jackson** 담당
    - @RequestParam, @PathVariable: URL의 path variable과 query parameter를 Java 객체로 변환, **Spring ConversionService** 담당
    
    → 이 둘은 변환 실패 시 던지는 예외도 다르다
    
    | **경로** | **실패 시 던지는 예외** | **예시** |
    | --- | --- | --- |
    | JSON Body | `HttpMessageNotReadableException` | `"boardType": "ABC”` |
    | URL Query/Path | `MethodArgumentTypeMismatchException` | `?boardType=ABC`, `/posts/abc` |
    
    ⇒ GlobalExceptionHandler에는 **두 예외 각각**에 400 응답 핸들러를 추가함
    

1. **DTO 설계**
    
    Domain(Post)은 class, DTO는 record로 분리
    
    - Domain은 상태 변경(update 메서드 등)이 필요하고, 추후 JPA도 적용해야 하므로 mutable한 class로 선언
    - DTO는 순수 데이터 전달 객체이고, 상태를 가지지 않아도 되므로(한 번 선언되면 바뀌지 않아야하므로) 필드를 내부적으로 final로 관리하는 record로 선언
    
    +) API 명세에는 게시글 목록용 응답, 게시글 상세조회용 응답 형식이 다른데, 이번 과제에서는 목록용/상세용 Response DTO 분리는 하지 않았습니다ㅎㅎ
    

1. **게시글 목록 조회 Pagination, BoardType에 따른 필터링**
    
    ```java
    // PostController
    
    @GetMapping
    public ResponseEntity<ApiResponse<PageResponse<PostResponse>>> getAllPosts(
            @RequestParam(defaultValue = "0") int page,
            @RequestParam(defaultValue = "10") int size,
            @RequestParam(required = false) BoardType boardType
    ) {
        PageResponse<PostResponse> pageData = postService.getAllPosts(page, size, boardType);
        return ResponseEntity.status(SuccessCode.POST_LIST_FETCH_SUCCESS.getStatus())
                .body(ApiResponse.success(SuccessCode.POST_LIST_FETCH_SUCCESS, pageData));
    }
    ```
    
    - 하나의 GET /posts 엔드포인트에서 세 개 쿼리 파라미터 처리: `page`, `size`, `boardType`
    - `page`, `size`는 `defaultValue`를 사용하도록, boardType은 `required=false`로 설정
        - `defaultValue`: 클라에서 값을 보내지 않으면 `defaultValue`에 설정된 기본값이 적용됨, `null`이 불가함.
            
            클라에서 page, size를 보내지 않으면 기본값이 적용되고, 값을 보낸다면 해당 값으로 페이지네이션을 적용하는게 자연스럽다고 생각
            
        - `required = false`: 클라에서 값을 보내지 않으면 `null`이 들어감
            
            게시판 전체조회 / 특정 게시판 조회를 구분해야하므로, 클라에서 boardType에 아무런 값도 보내지 않으면 boardType을 null로 설정해 게시판 전체를 조회하고, 특정 boardType을 명시한다면 해당 게시판으로 필터링되도록 적용하는게 자연스럽다고 생각
            
    - 페이징 계산은 Service 레이어에서 수행
        
        boardType에 따른 필터링 + page, size에 따른 슬라이싱 + DTO 변환 모두 Service의 책임이라고 생각

### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

- **개발 환경 관련**
    
    **IntelliJ 포맷 설정**
    
    혼자 개발할 때는 IntelliJ 내장 포맷터로 충분하지만, 협업 시 팀원마다 IntelliJ 내장 포맷터 설정도 달라질텐데 포맷팅 관련 설정을 어떻게 맞추는지 궁금해요. 웹 개발할 때 사용하는 ESLint/Prettier같이 팀 단위로 코드 포맷을 강제할 수 있는 도구가 있는지 알아봤는데, google-java-format같은 플러그인도 있더라고요. 근데 실제로 잘 사용하는 플러그인인지는 잘 모르겠네요..
    
    **IntelliJ 성능** 
    
    Spring Boot 설치 이후 IntelliJ가 눈에 띄게 느려졌어요. 파일 이동도 제대로 안되고 타이핑도 초 단위로 지연되길래 이유를 알아봤는데, IntelliJ의 기본 Heap 메모리가 2GB로 설정되어있어 Spring 프로젝트에는 부족한게 원인이었어요. IntelliJ → Help → Change Memory Settings에서 힙 메모리를 4096MB로 올리니까 바로 쾌적해지더라고요ㅎㅎ

<br>

### 화면 캡처

- 게시글 생성
<img width="423" height="221" alt="image" src="https://github.com/user-attachments/assets/b9e2ebbf-1a47-497b-9f26-b1977ca3f348" />

- 게시글 목록 조회
<img width="718" height="507" alt="image" src="https://github.com/user-attachments/assets/22a4786e-40f2-4d55-a47d-c31f564aca79" />
<img width="714" height="444" alt="image" src="https://github.com/user-attachments/assets/59e1f08f-c3d4-4108-bdba-f28c4fb7fb1b" />

- 게시글 상세 조회
<img width="420" height="336" alt="image" src="https://github.com/user-attachments/assets/69ecb487-6f2b-4586-9a1b-0d30df16dde6" />

- 게시글 수정 
<img width="421" height="194" alt="image" src="https://github.com/user-attachments/assets/ff85cbe2-de5b-45c7-afdf-6125294144aa" />

- 게시글 수정 확인용 재조회
<img width="420" height="339" alt="image" src="https://github.com/user-attachments/assets/5e4ee81f-6cdb-44c4-a307-7146b94d8885" />

- 게시글 삭제
<img width="422" height="203" alt="image" src="https://github.com/user-attachments/assets/6c2abe27-95b5-4227-85fa-b0914e1f3ff5" />

- 페이지네이션
<img width="415" height="739" alt="image" src="https://github.com/user-attachments/assets/eb441073-0f22-47b2-a655-d1a4218f817e" />

- boardType 필터링 - FREE만
<img width="420" height="438" alt="image" src="https://github.com/user-attachments/assets/8931f859-69c6-40f4-a48b-62c278d1e86e" />

- 404: 없는 게시글 조회
<img width="423" height="231" alt="image" src="https://github.com/user-attachments/assets/2095d588-e5f0-4b51-9bf8-507ece341e8b" />

- 400: 제목 50자 초과
<img width="424" height="200" alt="image" src="https://github.com/user-attachments/assets/d40d10e0-8f8d-4e62-a03a-759c531c6e75" />

- 400: 잘못된 boardType (JSON Body)
<img width="423" height="135" alt="image" src="https://github.com/user-attachments/assets/3a8abb4c-bd13-4a1f-b083-ed3af5953a15" />


- 400: 잘못된 boardType (Query Param)
<img width="422" height="212" alt="image" src="https://github.com/user-attachments/assets/44b26a98-6a68-4ad5-aa8d-a56f045337c7" />



---
### **키워드 과제 정리내용**

<details>
<summary><b>키워드 과제</b></summary>

1. HTTP 멱등성 (Idempotency)
    
    같은 요청을 여러 번 해도 결과가 변하지 않는 성질을 말함.
    
    - 멱등한 메서드: GET, PUT, DELETE
        - GET: 조회를 100번 해도 결과 동일
        - PUT: 같은 값으로 여러 번 수정해도 최종 상태 동일
        - DELETE: 두 번 이상 삭제 시도해도 결국 삭제된 상태는 같음
    - 멱등하지 않은 메서드: POST
        - POST 요청 3번 → 게시글 3개 생성. 매번 새 리소스가 만들어짐.
    
    멱등성을 고려한 설계가 중요한 이유는 네트워크 불안정으로 요청이 중복 전송될 수 있기 때문. 
    ex: 결제 시스템에서 POST가 중복으로 도착하면 결제가 두 번 되는 문제가 생김.
    

1. @Controller vs @RestController
    - @Controller: 메서드 반환값을 뷰 이름(HTML 파일) 으로 해석. SSR 방식에서 사용.
    - @RestController: @Controller + @ResponseBody의 합본. 반환값을 JSON으로 자동 변환해서 HTTP Body에 실어줌.
    
    ```java
    @Controller
    public String createPost() {
    	return "post-created"; // "post-created.html" 뷰를 찾음
    }
    
    @RestController
    public CreatePostResponse createPost() {
    	return new CreatePostResponse(1L, "완료!"); // JSON으로 직렬화돼서 응답
    }
    ```
    

1. Java Record
    
    불변 데이터 클래스를 한 줄로 정의할 수 있는 문법 (Java 16 정식).
    
    `public record PostResponse(Long id, String title) { }`
    
    - 필드 모두 final로 선언 (불변)
    - 인자 받는 생성자
    - 접근자 메서드 (.id(), .title())
    - equals(), hashCode(), toString()
    
    기존 class와 차이
    
    - 불변성 강제: setter 못 만듦, 필드도 final
    - 코드 간결: 15~20줄짜리 POJO가 1~3줄이 됨
    - 제약: 다른 클래스 상속 불가 (이미 Record 클래스 상속 중)
    - 용도: 순수 데이터 전달용 (DTO, Value Object 등)에 최적. 상태 변경이 필요한 도메인 엔티티엔 부적합.

1. Optional
    
    값이 있을 수도, 없을 수도 있음을 타입으로 명시하는 wrapper 클래스.
    
    ```java
    // Optional 없이 — "null 반환할 수도 있음"이 코드에 안 보임
    Post post = postRepository.findById(1L);
    post.getTitle();  // post가 null이면 NullPointerException
    
    // Optional 사용 — "값이 없을 수도 있음"이 타입에 드러남
    Optional<Post> post = postRepository.findById(1L);
    post.orElseThrow(() -> new PostNotFoundException());
    ```
    
    null 대신 쓰는 이유
    
    - 명시성: 반환 타입이 Optional<Post>면 "없을 수 있는 값"이 명확히 드러남. Post 반환 시엔 호출자가 null 가능성을 놓칠 수 있음.
    - NullPointerException 방지: orElseThrow, orElse, ifPresent 등의 메서드로 명시적 처리를 강제. null 체크 빠뜨릴 가능성을 줄여줌.
    - 함수형 API와 결합: .map(), .filter() 같은 체이닝이 가능해 null 분기 없이 데이터 변환이 깔끔해짐.

1. Spring Bean 생명주기
    
    기본 Singleton scope 기준 흐름.
    
    1. 인스턴스화 : Spring Container가 클래스를 new로 생성
    2. 의존성 주입 : 생성자/필드/Setter로 필요한 Bean 주입
    3. 초기화 콜백 : @PostConstruct 메서드 실행 (있으면)
    4. 사용 : 앱 전체에서 Bean 재사용
    5. 소멸 콜백 : 앱 종료 시 @PreDestroy 메서드 실행 (있으면)
    6. Bean 제거 : Container가 Bean 정리
    
    커스텀 초기화/소멸
    
    ```java
    @Service
    public class PostService {
        @PostConstruct
        public void init() { /* Bean 준비되면 실행할 로직 */ }
    
        @PreDestroy
        public void cleanup() { /* 종료 전 정리 로직 */ }
    }
    ```
    
    Singleton Bean은 앱 전체에서 하나의 인스턴스를 공유하므로, 생성 시점(앱 시작)과 소멸 시점(앱 종료)이 명확함.
    

1. Spring Boot 구동 원리 DispatcherServlet 중심
    
    앱 시작 흐름
    
    1. main() → SpringApplication.run(...)
    2. @SpringBootApplication이 아래 셋을 활성화:
        - @ComponentScan : Bean 자동 스캔
        - @EnableAutoConfiguration : 의존성 기반 자동 설정
        - @SpringBootConfiguration : 설정 클래스로 등록
    3. 내장 Tomcat 기동 (기본 8080 포트)
    4. DispatcherServlet을 Tomcat에 등록
    5. @Controller / @Service / @Repository 등의 Bean 전부 등록 완료
    6. 준비 완료 → 요청 대기
    
    요청 처리 흐름 (DispatcherServlet 중심)
    
    ```
    클라 요청 (GET /posts)
    ↓
    Tomcat: HTTP 원문을 HttpServletRequest 객체로 변환
    ↓
    DispatcherServlet (Front Controller): 모든 요청의 진입점
    ↓
    HandlerMapping: URL + HTTP 메서드 → Controller 메서드 매칭
    (앱 시작 시 @RequestMapping 정보로 라우팅 테이블 구성됨)
    ↓
    HandlerAdapter: 메서드 파라미터 준비 후 호출
    - @RequestBody 변환 (Jackson)
    - @RequestParam, @PathVariable 변환 (ConversionService)
    ↓
    Controller 메서드 실행 → Service → Repository
    ↓
    반환값 (Java 객체)
    ↓
    MessageConverter(Jackson): Java 객체 → JSON 직렬화
    ↓
    HttpServletResponse 작성
    ↓
    Tomcat이 클라에 응답 전송
    ```

</details>


---

## 🚨 참고 사항

생소한 내용들 정리하느라 주석이 좀 많아요..!